### PR TITLE
feat: derive child ticket numbers from parent

### DIFF
--- a/app/api/tickets/[id]/children/route.ts
+++ b/app/api/tickets/[id]/children/route.ts
@@ -1,24 +1,7 @@
 // app/api/tickets/[id]/children/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { pool } from "@/lib/db";
-import type { PoolConnection } from "mysql2/promise";
-
-// Generate daily ticket number: NH360-YYYYMMDD-###
-async function generateTicketNo(conn: PoolConnection): Promise<string> {
-  const now = new Date();
-  const yyyy = now.getFullYear();
-  const mm = String(now.getMonth() + 1).padStart(2, "0");
-  const dd = String(now.getDate()).padStart(2, "0");
-  const todayStr = `${yyyy}${mm}${dd}`;
-
-  const [rows] = await conn.query(
-    "SELECT COUNT(*) AS count FROM tickets_nh WHERE DATE(created_at) = CURDATE()"
-  );
-  // @ts-ignore
-  const todayCount = rows?.[0]?.count ?? 0;
-  const seq = String(todayCount + 1).padStart(3, "0");
-  return `NH360-${todayStr}-${seq}`;
-}
+import { generateChildTicketNo } from "@/lib/ticket-numbers";
 
 // GET: list all child sub-tickets for a parent ticket
 export async function GET(
@@ -82,7 +65,7 @@ export async function POST(
 
     await conn.beginTransaction();
 
-    const ticket_no = await generateTicketNo(conn);
+    const ticket_no = await generateChildTicketNo(conn, parentId, parent.ticket_no);
 
     // Inherit/override fields
     const vehicle_reg_no = body.vehicle_reg_no ?? parent.vehicle_reg_no ?? "";
@@ -121,7 +104,11 @@ export async function POST(
     const newId = Number(r.insertId);
 
     await conn.commit();
-    return NextResponse.json({ ok: true, id: newId, ticket_no }, { status: 201 });
+    const [[child]]: any = await conn.query(
+      "SELECT * FROM tickets_nh WHERE id = ?",
+      [newId],
+    );
+    return NextResponse.json({ ok: true, child }, { status: 201 });
   } catch (e: any) {
     await conn.rollback();
     console.error("POST /api/tickets/[id]/children error:", e);

--- a/app/api/tickets/route.ts
+++ b/app/api/tickets/route.ts
@@ -1,24 +1,7 @@
 // app/api/tickets/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { pool } from "@/lib/db";
-import type { PoolConnection } from "mysql2/promise";
-
-// --- utility: make a ticket_no like NH360-YYYYMMDD-###, inside a txn ---
-async function generateTicketNo(conn: PoolConnection): Promise<string> {
-  const now = new Date();
-  const yyyy = now.getFullYear();
-  const mm = String(now.getMonth() + 1).padStart(2, "0");
-  const dd = String(now.getDate()).padStart(2, "0");
-  const todayStr = `${yyyy}${mm}${dd}`;
-
-  const [rows] = await conn.query(
-    "SELECT COUNT(*) AS count FROM tickets_nh WHERE DATE(created_at) = CURDATE()"
-  );
-  // @ts-ignore - RowDataPacket
-  const todayCount = rows?.[0]?.count || 0;
-  const seq = String(todayCount + 1).padStart(3, "0");
-  return `NH360-${todayStr}-${seq}`;
-}
+import { generateTicketNo, generateChildTicketNo } from "@/lib/ticket-numbers";
 
 // GET:
 // - default: ONLY parent tickets (sub-tickets excluded)
@@ -120,7 +103,7 @@ export async function POST(req: NextRequest) {
 
     // --- CASE A: create only a sub-ticket (no new parent) ---
     if (parent_ticket_id) {
-      const childTicketNo = await generateTicketNo(conn);
+      const childTicketNo = await generateChildTicketNo(conn, parent_ticket_id);
 
       if (!subject || !String(subject).trim()) {
         throw new Error("Subject is required for sub-ticket");
@@ -150,12 +133,15 @@ export async function POST(req: NextRequest) {
       );
 
       await conn.commit();
+      const [[child]]: any = await conn.query(
+        "SELECT * FROM tickets_nh WHERE id = ?",
+        [r.insertId],
+      );
       return NextResponse.json({
         ok: true,
         mode: "sub_only",
         parent_id: parent_ticket_id,
-        child_id: r.insertId,
-        child_ticket_no: childTicketNo,
+        child,
       });
     }
 
@@ -190,7 +176,7 @@ export async function POST(req: NextRequest) {
         const c_subject = row.subject;
         if (!c_subject || !String(c_subject).trim()) continue;
 
-        const childTicketNo = await generateTicketNo(conn);
+        const childTicketNo = await generateChildTicketNo(conn, parentId, ticket_no_parent);
 
         await conn.query(
           `INSERT INTO tickets_nh
@@ -219,12 +205,22 @@ export async function POST(req: NextRequest) {
     }
 
     await conn.commit();
+    const [[parentRow]]: any = await conn.query(
+      "SELECT * FROM tickets_nh WHERE id = ?",
+      [parentId],
+    );
+    const [childRows]: any = await conn.query(
+      "SELECT * FROM tickets_nh WHERE parent_ticket_id = ? ORDER BY created_at DESC",
+      [parentId],
+    );
     return NextResponse.json({
       ok: true,
       mode: "parent_with_optional_subs",
       parent_id: parentId,
       parent_ticket_no: ticket_no_parent,
       children_created: childrenCreated,
+      parent: parentRow,
+      children: childRows,
     });
   } catch (e: any) {
     await conn.rollback();

--- a/lib/ticket-numbers.ts
+++ b/lib/ticket-numbers.ts
@@ -1,0 +1,45 @@
+import type { PoolConnection } from "mysql2/promise";
+
+// Generate ticket number like NH360-YYYYMMDD-### for parent tickets
+export async function generateTicketNo(conn: PoolConnection): Promise<string> {
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  const todayStr = `${yyyy}${mm}${dd}`;
+
+  const [rows] = await conn.query(
+    "SELECT COUNT(*) AS count FROM tickets_nh WHERE DATE(created_at) = CURDATE()",
+  );
+  // @ts-ignore - RowDataPacket
+  const todayCount = rows?.[0]?.count || 0;
+  const seq = String(todayCount + 1).padStart(3, "0");
+  return `NH360-${todayStr}-${seq}`;
+}
+
+// Generate ticket number for a child ticket using parent ticket_no
+export async function generateChildTicketNo(
+  conn: PoolConnection,
+  parentId: number,
+  parentTicketNo?: string,
+): Promise<string> {
+  let base = parentTicketNo;
+  if (!base) {
+    const [prow]: any = await conn.query(
+      "SELECT ticket_no FROM tickets_nh WHERE id = ?",
+      [parentId],
+    );
+    base = prow?.[0]?.ticket_no;
+  }
+  if (!base) {
+    throw new Error("Parent ticket not found");
+  }
+
+  const [rows]: any = await conn.query(
+    "SELECT COUNT(*) AS count FROM tickets_nh WHERE parent_ticket_id = ?",
+    [parentId],
+  );
+  const count = rows?.[0]?.count || 0;
+  const seq = String(count + 1).padStart(2, "0");
+  return `${base}-${seq}`;
+}


### PR DESCRIPTION
## Summary
- ensure child tickets use parent's ticket number with incremental suffixes
- centralize ticket number generation helpers
- include full ticket data in create responses so new tickets load immediately

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af352efe6c833194fbbc3a1303f183